### PR TITLE
re-labeled "raw" fields as "markdown"

### DIFF
--- a/MST698S_Session4_NLP.ipynb
+++ b/MST698S_Session4_NLP.ipynb
@@ -28,7 +28,7 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "In the space below, specify the location of the news_text.txt file:"
@@ -46,7 +46,7 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Now, the following function can be used to import the news article as a string:"
@@ -68,7 +68,7 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "In the space below, use the above function to open the news_text.txt content, and print the resulting string:"
@@ -82,7 +82,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Now, in the space below, import TextBlob using the following:\n",
@@ -100,7 +100,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "The first step is to instantiate a TextBlob object from a string of text.  This can be done as follows:\n",
@@ -136,7 +136,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Now, we want to pick out sentences that specificially mention the U.S. political candidates, since we are only interested in the affect surrounding those individuals.  The candidates in question are former Vice President Joe Biden, and Senator Bernie Sanders.  First, let's filter the article sentences so that we are only analyzing sentences that mention Mr. Biden:\n",
@@ -159,7 +159,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Now, in the space below, do the same for Mr. Sanders:"
@@ -173,7 +173,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "The next step is to measure the sentiment of each sentence, and then calculate an average sentiment for each candidate.  Sentiment has two components - objectivity and polarity.  Objectivity is the measure of how objective verses subjective a sentence is, and ranges from 0 for completely objective, to 1 for completely subjective.  Polarity is the measure of affect - how postive or negative the \"feeling\" is of the that particular sentence, and ranges from -1 (\"bad\" feelings) to +1 (\"good\" feelings).\n",
@@ -208,7 +208,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Now, we want to loop through the sentences in each list and append the sentiment (product of polarity and subjectivity) to each list.  We can do this as follows:\n",
@@ -229,7 +229,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Now, in the space below, repeat this for former Vice President Biden:"
@@ -243,7 +243,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Now, calculate the average sentiment of Senator Sanders.  Note that you will have to import the Numpy library to do this:\n",
@@ -262,7 +262,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Now, in the space below, do this for Vice President Biden:"
@@ -276,7 +276,7 @@
    "source": []
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Obviously, this exercise is based on only one article, so we can't derive a statistically robust inference.  However, based on this cursory analysis, do you think this article favors Mr. Sanders or Mr. Biden (the higher the number, the better the feeling)?  Why?\n",


### PR DESCRIPTION
Several markdown fields had a "cell_type" labeled as "raw" I updated that as "markdown".  This should fix the file  and make it more accessible in various jupyter environments.  Also, it makes it easier to read in github.